### PR TITLE
Fix tf to pt conversion by including a dummy variable back

### DIFF
--- a/transformers/modeling_tf_bert.py
+++ b/transformers/modeling_tf_bert.py
@@ -473,22 +473,33 @@ class TFBertMainLayer(tf.keras.layers.Layer):
     def call(self, inputs, attention_mask=None, token_type_ids=None, position_ids=None, head_mask=None, training=False):
         if isinstance(inputs, (tuple, list)):
             input_ids = inputs[0]
+            input_ids = tf.cast(input_ids, dtype=tf.int32)
             attention_mask = inputs[1] if len(inputs) > 1 else attention_mask
             token_type_ids = inputs[2] if len(inputs) > 2 else token_type_ids
+            token_type_ids = tf.cast(token_type_ids, dtype=tf.int32)
+
             position_ids = inputs[3] if len(inputs) > 3 else position_ids
+            position_ids = tf.cast(position_ids, dtype=tf.int32)
+
             head_mask = inputs[4] if len(inputs) > 4 else head_mask
             assert len(inputs) <= 5, "Too many inputs."
         elif isinstance(inputs, dict):
             input_ids = inputs.get('input_ids')
+            input_ids = tf.cast(input_ids, dtype=tf.int32)
             attention_mask = inputs.get('attention_mask', attention_mask)
             token_type_ids = inputs.get('token_type_ids', token_type_ids)
+            token_type_ids = tf.cast(token_type_ids, dtype=tf.int32)
             position_ids = inputs.get('position_ids', position_ids)
+            position_ids = tf.cast(position_ids, dtype=tf.int32)
+
             head_mask = inputs.get('head_mask', head_mask)
             assert len(inputs) <= 5, "Too many inputs."
         else:
             input_ids = inputs
+            input_ids = tf.cast(input_ids, dtype=tf.int32)
 
-        input_ids = tf.cast(input_ids, dtype=tf.int32)
+
+
 
         if attention_mask is None:
             attention_mask = tf.fill(tf.shape(input_ids), 1)

--- a/transformers/modeling_tf_bert.py
+++ b/transformers/modeling_tf_bert.py
@@ -488,6 +488,8 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         else:
             input_ids = inputs
 
+        input_ids = tf.cast(input_ids, dtype=tf.int32)
+
         if attention_mask is None:
             attention_mask = tf.fill(tf.shape(input_ids), 1)
         if token_type_ids is None:

--- a/transformers/modeling_tf_pytorch_utils.py
+++ b/transformers/modeling_tf_pytorch_utils.py
@@ -25,6 +25,8 @@ import numpy
 
 logger = logging.getLogger(__name__)
 
+DUMMY_INPUTS = [[7, 6, 0, 0, 1], [1, 2, 3, 0, 0], [0, 0, 0, 4, 5]]
+
 def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove=''):
     """ Convert a TF 2.0 model variable name in a pytorch model weight name.
 


### PR DESCRIPTION
We added a DUMMY_VARIABLE to make sure the tf model is built after creation.  It was already included in the older version of the file but removed for some obvious reasons (probably to make it a generic method for various types of models with different input formats). However, since the current state of the file is not suitable to load any model, we included it back until a complete solution is developed.